### PR TITLE
add FieldHooks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,10 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - "!main"
 name: Test
 jobs:
   test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,8 +3,7 @@ on:
     branches:
     - main
   pull_request:
-    branches:
-    - "!main"
+
 name: Test
 jobs:
   test:


### PR DESCRIPTION
This allows adding `func(any) any` functions that get run on `SetField(s)` which can do things like auto redact structs.