### PR TITLE
joinederr package for unwrapping after errors.Join

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.20.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/ctxerr.go
+++ b/ctxerr.go
@@ -93,6 +93,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/mvndaai/ctxerr/joinederr"
 )
 
 var global Instance
@@ -378,7 +380,9 @@ func (in Instance) AllFields(err error) map[string]any {
 		fieldFuncs = append(fieldFuncs, DefaultFieldsFunc)
 	}
 
+	iter := joinederr.NewDepthFirstIterator(err)
 	for {
+		err = iter.Next()
 		if err == nil {
 			return f
 		}
@@ -403,7 +407,6 @@ func (in Instance) AllFields(err error) map[string]any {
 			}
 			f[k] = v
 		}
-		err = errors.Unwrap(err)
 	}
 }
 
@@ -415,7 +418,9 @@ func (in Instance) HasField(err error, field string) bool {
 		fieldFuncs = append(fieldFuncs, DefaultFieldsFunc)
 	}
 
+	iter := joinederr.NewDepthFirstIterator(err)
 	for {
+		err = iter.Next()
 		if err == nil {
 			return false
 		}
@@ -430,8 +435,6 @@ func (in Instance) HasField(err error, field string) bool {
 		if _, ok := fields[field]; ok {
 			return true
 		}
-
-		err = errors.Unwrap(err)
 	}
 }
 
@@ -457,7 +460,9 @@ func (in Instance) HasCategory(err error, category any) bool {
 		fieldFuncs = append(fieldFuncs, DefaultFieldsFunc)
 	}
 
+	iter := joinederr.NewDepthFirstIterator(err)
 	for {
+		err = iter.Next()
 		if err == nil {
 			return false
 		}
@@ -474,8 +479,6 @@ func (in Instance) HasCategory(err error, category any) bool {
 				return true
 			}
 		}
-
-		err = errors.Unwrap(err)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/mvndaai/ctxerr
 
-go 1.18
+go 1.20

--- a/joinederr/joinederr.go
+++ b/joinederr/joinederr.go
@@ -1,0 +1,54 @@
+package joinederr
+
+type ErrorIterator interface {
+	Next() error
+	HasNext() bool
+}
+
+type depthFirstUnwrapper struct {
+	next       error
+	nextParent []error
+}
+
+func (bfu *depthFirstUnwrapper) Next() error {
+	if bfu.next == nil {
+		return nil
+	}
+
+	// Split joined errors
+	if x, ok := bfu.next.(interface{ Unwrap() []error }); ok {
+		errs := x.Unwrap()
+		if len(errs) > 0 {
+			bfu.next = errs[0]
+			bfu.nextParent = append(errs[1:], bfu.nextParent...)
+		}
+	}
+
+	// Set return value
+	r := bfu.next
+
+	// Setup next return value
+	bfu.next = nil
+
+	if x, ok := r.(interface{ Unwrap() error }); ok {
+		bfu.next = x.Unwrap()
+	}
+
+	if bfu.next == nil {
+		if len(bfu.nextParent) > 0 {
+			bfu.next = bfu.nextParent[0]
+			bfu.nextParent = bfu.nextParent[1:]
+		}
+	}
+
+	// Return
+	return r
+}
+
+func (bfu *depthFirstUnwrapper) HasNext() bool {
+	return bfu.next != nil
+}
+
+func NewDepthFirstIterator(err error) ErrorIterator {
+	return &depthFirstUnwrapper{next: err}
+}

--- a/joinederr/joinederr_test.go
+++ b/joinederr/joinederr_test.go
@@ -1,0 +1,71 @@
+package joinederr_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/mvndaai/ctxerr/joinederr"
+)
+
+func TestBreadthFirst(t *testing.T) {
+	/*
+				a
+			   / \
+			  /   \
+			b      f
+		   / \     |
+		  c   e    g
+		  |       / \
+		  d	     h   i
+	*/
+
+	i := errors.New("i")
+	h := errors.New("h")
+	g := fmt.Errorf("g\n%w", errors.Join(h, i))
+	f := fmt.Errorf("f\n%w", g)
+	d := errors.New("d")
+	c := fmt.Errorf("c\n%w", d)
+	e := errors.New("e")
+	b := fmt.Errorf("b\n%w", errors.Join(c, e))
+	a := fmt.Errorf("a\n%w", errors.Join(b, f))
+
+	msgs := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}
+	actualMsg := a.Error()
+	expectedMessage := strings.Join(msgs, "\n")
+	if actualMsg != expectedMessage {
+		t.Errorf("message did not match\n%#v\n%#v", actualMsg, expectedMessage)
+	}
+
+	expectedTrees := [][]string{
+		{"a", "b", "c", "d", "e", "f", "g", "h", "i"},
+		{"b", "c", "d", "e"},
+		{"c", "d"},
+		{"d"},
+		{"e"},
+		{"f", "g", "h", "i"},
+		{"g", "h", "i"},
+		{"h"},
+		{"i"},
+	}
+	var expectTreeCount int
+
+	iter := joinederr.NewDepthFirstIterator(a)
+	for iter.HasNext() {
+		actualMsg := strings.ReplaceAll(iter.Next().Error(), "\n", ":")
+		expectedMessage := strings.Join(expectedTrees[expectTreeCount], ":")
+		if actualMsg != expectedMessage {
+			t.Errorf("message [%v] did not match\n%#v\n%#v", expectTreeCount, actualMsg, expectedMessage)
+		}
+		expectTreeCount++
+	}
+
+	if expectTreeCount != len(expectedTrees) {
+		t.Errorf("stopped iterating [%v] setps early", len(expectedTrees)-expectTreeCount)
+	}
+
+	if iter.Next() != nil {
+		t.Error("this there should be nothing left")
+	}
+}


### PR DESCRIPTION
* Iterator for doing a depth first search for unwrapping
  * Handles either interface `Unwrap() error` from fmt.Errorf("%w") or `Unwrap() []error` from errors.Join
* Uses iterator for `AllFields`, `HasField`, and `HasCategory`